### PR TITLE
Push to Dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,38 @@
-jobs:
+version: 2.1
 
-  build-controller-image:
+jobs:
+  build-image:
     machine:
       docker_layer_caching: true
     steps:
       - checkout
       - run:
           name: Build controller image
-          command: make gordo-controller
+          command: make controller
+          no_output_timeout: 20m
+
+  push-image:
+    machine:
+      docker_layer_caching: true
+    environment:
+      GORDO_PROD_MODE: true
+    steps:
+      - checkout
+      - run:
+          name: Push Image
+          command: |
+            echo $(docker images)
+            make push-prod-controller
 
 workflows:
-  version: 2
   build-and-test:
     jobs:
-      - build-controller-image
+      - build-image
+      - push-image:
+          requires:
+            - build-image
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /.*/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
-GORDO_CONTROLLER_IMG_NAME := gordo-infrastructure/gordo-controller
+export DOCKER_REGISTRY := docker.io
+GORDO_CONTROLLER_IMG_NAME := equinor/gordo-controller
 
-gordo-controller:
+controller:
 	docker build . -f Dockerfile-controller -t $(GORDO_CONTROLLER_IMG_NAME)
 
-.PHONY: gordo-controller
+push-controller:
+	export DOCKER_NAME=$(GORDO_CONTROLLER_IMG_NAME);\
+	export DOCKER_IMAGE=$(GORDO_CONTROLLER_IMG_NAME);\
+	./docker_push.sh
+
+push-dev-controller: push-controller
+
+push-prod-controller: export GORDO_PROD_MODE:="true"
+push-prod-controller: push-controller
+
+.PHONY: controller push-dev-controller push-prod-controller push-controller

--- a/docker_push.sh
+++ b/docker_push.sh
@@ -1,0 +1,73 @@
+# Script to push an docker image to a docker registry. The docker image can
+# either exist and be provided in the env variable DOCKER_IMAGE, or it will be
+# built if DOCKER_IMAGE is empty and DOCKER_FILE is provided
+#
+# If $DOCKER_USERNAME is set then it will attempt to log in to the
+# $DOCKER_REGISTRY using $DOCKER_USERNAME and DOCKER_PASSWORD, otherwise it
+# assumes that you are already logged in.
+#
+# Pushes a docker image with name DOCKER_NAME, and tag tag with the 8 first
+# chars of the git commit, and if the current commit is tagged it also pushes
+# with those tags. So e.g. if git HEAD is commit "3f6f963" and with tag "0.0.2"
+# then two tags are pushed, both "gordo-infrastructure/gordo-deploy:3f6f963" and
+# "gordo-infrastructure/gordo-deploy:0.0.2" if DOCKER_NAME is
+# "gordo-infrastructure/gordo-deploy".
+#
+# Expects the following environment variables to be set:
+# DOCKER_NAME: Required. Docker name to push to.
+# DOCKER_FILE: Semi-Required. Dockerfile to build. Either DOCKER_IMAGE or
+#              DOCKER_FILE must be set.
+# DOCKER_IMAGE: Semi-Required. The local docker image to push. Either
+#               DOCKER_IMAGE or DOCKER_FILE must be set.
+# DOCKER_USERNAME: If set then it uses it an the password to log in to the
+#                  registry
+# DOCKER_PASSWORD: If set then it uses it an the username to log in to the
+#                  registry
+# DOCKER_REGISTRY: Docker registry to push to. Defaults to
+#                  auroradevacr.azurecr.io
+# GORDO_PROD_MODE: If false then pushed tags will include a -dev suffix.
+#                  Defaults to false
+
+if [[ -z "${DOCKER_NAME}" ]]; then
+    echo "DOCKER_NAME must be set, exiting"
+    exit 1
+fi
+
+if [[ -z "${DOCKER_USERNAME}" ]]; then
+    echo "DOCKER_USERNAME not set: we assume that you are already logged in to the docker registry."
+else
+    # Logging in to the docker registry, exiting script if it fails
+    echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin $DOCKER_REGISTRY || exit 1
+fi
+
+export tmp_tag=$(date +%Y-%m-%d)
+
+if [[ -z "${DOCKER_IMAGE}" ]]; then
+    if [[ -z "${DOCKER_FILE}" ]]; then
+        echo "DOCKER_IMAGE or DOCKER_FILE must be provided, exiting"
+        exit 1
+    fi
+    docker build -t $tmp_tag  -f $DOCKER_FILE .
+    export DOCKER_IMAGE=$tmp_tag
+fi
+
+# Ensure we're getting the latest version, including any dirty state of the repo
+# replacing any '+' development identifier with an underscore for docker compatibility
+export version=$(git rev-parse --short HEAD)
+
+# Should we push 'latest', only if in prod mode.
+if [[ -z "${GORDO_PROD_MODE}" ]]; then
+    echo "Skipping pushing of 'latest' image"
+else
+    # if we're in prod mode, we'll push the latest image.
+    docker tag $DOCKER_IMAGE $DOCKER_REGISTRY/$DOCKER_NAME:latest
+    docker push $DOCKER_REGISTRY/$DOCKER_NAME:latest
+fi
+
+docker tag $DOCKER_IMAGE $DOCKER_REGISTRY/$DOCKER_NAME:$version
+docker push $DOCKER_REGISTRY/$DOCKER_NAME:$version
+
+git tag --points-at HEAD | while read -r tag ; do
+    docker tag $DOCKER_IMAGE $DOCKER_REGISTRY/$DOCKER_NAME:$tag
+    docker push $DOCKER_REGISTRY/$DOCKER_NAME:$tag
+done


### PR DESCRIPTION
Push 'latest' and git short hash versions on every commit to master, follows the same logic as gordo-infrastructure and components; except pushes to docker.io