### PR TITLE
Set never type main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "gordo-controller"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gordo-controller"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ impl Default for GordoStatus {
 }
 
 fn main() -> ! {
-    std::env::set_var("RUST_LOG", "info,kube=debug");
+    std::env::set_var("RUST_LOG", "info,kube=info");
     env_logger::init();
 
     let config = config::load_kube_config().unwrap_or_else(|_| {


### PR DESCRIPTION
- Set `main` to never return type (`!`). Handle all potential errors by logging them rather than exiting.
- Set the `kube` log level to `info`.