### PR TITLE
Delete old jobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "gordo-controller"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gordo-controller"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 

--- a/Dockerfile-controller
+++ b/Dockerfile-controller
@@ -8,13 +8,12 @@ COPY ./Cargo.toml ./Cargo.toml
 
 # This builds dependencies.
 RUN cargo build --release
-RUN rm src/*.rs
 
 # Copy in the actual source code for the project.
 COPY src/ src/
 
 # Build for release.
-RUN rm ./target/x86_64-unknown-linux-musl/release/gordo*
+RUN rm -rf ./target/x86_64-unknown-linux-musl/release/deps/gordo*
 RUN cargo build --release
 
 # Controller


### PR DESCRIPTION
Will close #3 

Problem :warning: 
-----------
When a `Gordo` is modified or deleted, its old `gordo-deploy` jobs remain. 

Solution :sunflower: 
-----------
Add new function which looks for all jobs which `metadata.labels.gordoProjectName` (which has also been added to launched `gordo-deploy` jobs) matches the `metadata.name` of the `Gordo`.