### PR TITLE
Update kube & k8s-openapi dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,8 +384,8 @@ version = "0.1.3"
 dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8s-openapi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "kube 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8s-openapi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kube 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -515,7 +515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "k8s-openapi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -539,7 +539,7 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.15.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -548,7 +548,7 @@ dependencies = [
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "k8s-openapi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "k8s-openapi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.10.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1613,9 +1613,9 @@ dependencies = [
 "checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
-"checksum k8s-openapi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "67f1f42d95221841fc66fd949591ad8ecbb133274aa739222fd06cef2cf894ef"
+"checksum k8s-openapi 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "30e2ac1496d5920d157d0eb5ab453b0af1e6622d5ffa8e7f9c60d435d13342da"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum kube 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4102b56d2b4d1d9726f3b4429fb1b7ac52bf3c966110d45183bd6f80cccc35"
+"checksum kube 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "999e096714140913deb79850f33a1cd99c38acf0824305604456ccd0bc2c6cde"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)" = "34fcd2c08d2f832f376f4173a231990fa5aef4e99fb569867318a227ef4c06ba"
 "checksum linked-hash-map 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kube = { version = "0.15.0", features = ["openapi"] }
-k8s-openapi = { version = "0.5.0", features = ["v1_15"] }
+kube = { version = "0.16.1", features = ["openapi"] }
+k8s-openapi = { version = "0.5.1", default-features = false, features = ["v1_15"] }
 log = "0.4.8"
 failure = "0.1.5"
 env_logger = "0.6.2"


### PR DESCRIPTION
[Change log for kube-rs](https://github.com/clux/kube-rs/blob/master/CHANGELOG.md) indicates mostly additions and reduced memory use for building.
