### PR TITLE
Max job name length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "gordo-controller"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gordo-controller"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -197,17 +197,13 @@ fn start_gordo_deploy_job(
 ) -> () {
     let gordo_config = serde_json::to_string(&gordo.spec.config).unwrap();
 
-    // Create the job.
-    let mut job_name = format!(
-        "gordo-dpl-{}-{}",
+    // Create the job name.
+    let job_name_suffix = format!(
+        "{}-{}",
         &gordo.metadata.name,
         &gordo.metadata.generation.map(|v| v as u32).unwrap_or(0)
     );
-    // Max length of name can only be 63 char in length, favoring the tail end of the name
-    if job_name.len() > 63 {
-        let len = job_name.len();
-        job_name = job_name[(len - 63)..len].to_owned();
-    }
+    let job_name = deploy_job_name("gordo-dpl-", &job_name_suffix);
 
     // Define the owner reference info
     let owner_ref = json!([
@@ -314,4 +310,18 @@ pub(crate) fn remove_gordo_deploy_jobs(gordo: &Gordo, client: &APIClient, namesp
             }),
         Err(e) => error!("Failed to list jobs: {:?}", e),
     }
+}
+
+/// Generate a name which is no greater than 63 chars in length
+/// always keeping the `prefix` and as much of `suffix` as possible, favoring its ending.
+pub fn deploy_job_name(prefix: &str, suffix: &str) -> String {
+    let suffix = suffix
+        .chars()
+        .rev()
+        .take(63 - prefix.len())
+        .collect::<Vec<char>>()
+        .iter()
+        .rev()
+        .collect::<String>();
+    format!("{}{}", prefix, suffix)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,11 +198,16 @@ fn start_gordo_deploy_job(
     let gordo_config = serde_json::to_string(&gordo.spec.config).unwrap();
 
     // Create the job.
-    let job_name = format!(
-        "gordo-deploy-job-{}-{}",
+    let mut job_name = format!(
+        "gordo-dpl-{}-{}",
         &gordo.metadata.name,
         &gordo.metadata.generation.map(|v| v as u32).unwrap_or(0)
     );
+    // Max length of name can only be 63 char in length, favoring the tail end of the name
+    if job_name.len() > 63 {
+        let len = job_name.len();
+        job_name = job_name[(len - 63)..len].to_owned();
+    }
 
     // Define the owner reference info
     let owner_ref = json!([

--- a/src/tests/test_controller.rs
+++ b/src/tests/test_controller.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use serde_yaml;
 
 use crate::tests::helpers;
-use crate::{Gordo, GordoEnvironmentConfig};
+use crate::{deploy_job_name, Gordo, GordoEnvironmentConfig};
 
 // We can create a gordo using the `example-gordo.yaml` file in the repo.
 #[test]
@@ -85,4 +85,23 @@ fn test_minor_version() {
     assert_eq!(crate::minor_version("0.33.0"), Some(33));
     assert_eq!(crate::minor_version("0.31.12"), Some(31));
     assert_eq!(crate::minor_version("0.abc.def"), None);
+}
+
+#[test]
+fn test_deploy_job_name() {
+    let prefix = "gordo-dpl-";
+
+    // Basic
+    let suffix = "some-suffix";
+    assert_eq!(&deploy_job_name(prefix, suffix), "gordo-dpl-some-suffix");
+
+    // Really long suffix
+    let mut suffix = std::iter::repeat("a").take(100).collect::<String>();
+    suffix.push_str("required-suffix");
+    let result = deploy_job_name(prefix, &suffix);
+    assert_eq!(result.len(), 63);
+    assert_eq!(
+        &result,
+        "gordo-dpl-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarequired-suffix"
+    );
 }


### PR DESCRIPTION
Will close #23 

- Change prefix of deploy job from `gordo-deploy-job` to `gordo-dpl`
- Ensure the generated name is at most 63 chars.