### PR TITLE
Don't panic when job submission fails, just log error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "gordo-controller"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gordo-controller"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,10 +275,7 @@ fn start_gordo_deploy_job(
 
     match jobs.create(&postparams, serialized_spec) {
         Ok(job) => info!("Submitted job: {:?}", job.metadata.name),
-        Err(e) => {
-            error!("Failed to submit job with error: {:?}", e);
-            unimplemented!("Haven't implemented a way to deal with this, exiting."); // Kubernetes will restart us
-        }
+        Err(e) => error!("Failed to submit job with error: {:?}", e)
     }
 
     // Update the status of this job


### PR DESCRIPTION
Got the following error:
```
ApiError AlreadyExists ("object is being deleted: jobs.batch \"gordo-dpl-paper-project-2\" already exists") }
thread 'main' panicked at 'not yet implemented: Haven't implemented a way to deal with this, exiting.', src/main.rs:280:13
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

It's a strange error in general, because `gordo-dpl-paper-project-2` can't be located anyway when manually looking for it. However it seems more appropriate to simply log the error in the job submission and continue running, because gordo-controller enters a CrashLoopBackoff because it keeps encountering this error, rather than logging it and continuing on with life. (@flikka)