### PR TITLE
Get namespace from loaded kubeconfig

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,9 +62,11 @@ fn main() -> ! {
     let kube_config = config::load_kube_config().unwrap_or_else(|_| {
         config::incluster_config().expect("Failed to get local kube config and incluster config")
     });
-    let client = APIClient::new(kube_config);
 
-    let namespace = std::env::var("NAMESPACE").unwrap_or("kubeflow".into());
+    let namespace = kube_config.default_ns.to_owned();
+    info!("Got default namespace of: {}", &namespace);
+
+    let client = APIClient::new(kube_config);
 
     let resource: Api<Gordo> = Api::customResource(client.clone(), "gordos")
         .version("v1")


### PR DESCRIPTION
Problem :sleeping: 
---
We depend on a `NAMESPACE` env var (which doesn't actually exist) but default to `kubeflow`

Solution :astonished: 
---
Use the [`default_ns`](https://docs.rs/kube/0.17.0/kube/config/struct.Configuration.html#structfield.default_ns) from the loaded config to see what namespace the pod is running in. 