### PR TITLE
Update Gordos as new Models arrive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ export DOCKER_REGISTRY := docker.io
 GORDO_CONTROLLER_IMG_NAME := equinor/gordo-controller
 
 test:
+	kubectl config use-context minikube
 	cargo test -- --test-threads=1
 
 controller:

--- a/example-gordo.yaml
+++ b/example-gordo.yaml
@@ -2,7 +2,7 @@
 apiVersion: equinor.com/v1
 kind: Gordo
 metadata:
-  name: gordo-crd-testing-project2
+  name: test-project
 
 spec:
   deploy-version: latest

--- a/example-gordo.yaml
+++ b/example-gordo.yaml
@@ -2,7 +2,7 @@
 apiVersion: equinor.com/v1
 kind: Gordo
 metadata:
-  name: test-project
+  name: test-project-name
 
 spec:
   deploy-version: latest

--- a/example-model.yaml
+++ b/example-model.yaml
@@ -2,6 +2,15 @@ apiVersion: equinor.com/v1
 kind: Model
 metadata:
   name: gordo-model-name
+  labels:
+    app: model-stache-gordo-model-name
+    app.kubernetes.io/name: model-server
+    app.kubernetes.io/component: model
+    app.kubernetes.io/part-of: gordo
+    app.kubernetes.io/managed-by: gordo
+    applications.gordo.equinor.com/project-name: test-project
+    applications.gordo.equinor.com/project-version: "1234"
+    applications.gordo.equinor.com/model-name: gordo-model-name
 spec:
 
   gordo-version: 0.40.0

--- a/example-model.yaml
+++ b/example-model.yaml
@@ -2,15 +2,14 @@ apiVersion: equinor.com/v1
 kind: Model
 metadata:
   name: gordo-model-name
-  labels:
-    app: model-stache-gordo-model-name
-    app.kubernetes.io/name: model-server
-    app.kubernetes.io/component: model
-    app.kubernetes.io/part-of: gordo
-    app.kubernetes.io/managed-by: gordo
-    applications.gordo.equinor.com/project-name: test-project
-    applications.gordo.equinor.com/project-version: "1234"
-    applications.gordo.equinor.com/model-name: gordo-model-name
+  ownerReferences:
+    - apiVersion: v1
+      blockOwnerDeletion: true
+      controller: true
+      kind: Gordo
+      name: test-project-name
+      uid: 123abc
+
 spec:
 
   gordo-version: 0.40.0

--- a/k8s/gordo-crd.yaml
+++ b/k8s/gordo-crd.yaml
@@ -8,6 +8,10 @@ spec:
     description: Number of Models defined in this Gordo
     name: Model-Count
     type: integer
+  - JSONPath: .status.n-models-built
+    description: Number of Models currently built
+    name: Models-Built
+    type: integer
   - JSONPath: .status.submission-status.Submitted
     description: Number of times this gordo has been submitted by gordo-deploy
     name: Submitted

--- a/src/crd/gordo/mod.rs
+++ b/src/crd/gordo/mod.rs
@@ -10,10 +10,7 @@ pub mod gordo;
 pub use gordo::*;
 
 pub async fn monitor_gordos(client: &APIClient, namespace: &str, env_config: &GordoEnvironmentConfig) -> ! {
-    let gordo_resource: Api<Gordo> = Api::customResource(client.clone(), "gordos")
-        .version("v1")
-        .group("equinor.com")
-        .within(&namespace);
+    let gordo_resource: Api<Gordo> = load_gordo_resource(&client, &namespace);
     let gordo_informer: Informer<Gordo> = Informer::new(gordo_resource.clone()).init().await.unwrap();
 
     // On start up, get a list of all gordos, and start gordo-deploy jobs for each

--- a/src/crd/model/mod.rs
+++ b/src/crd/model/mod.rs
@@ -5,10 +5,12 @@ use kube::{
     api::{Api, Informer, PatchParams, WatchEvent},
     client::APIClient,
 };
-use log::{error, info};
+use log::{error, info, warn};
 use serde_json::json;
 
+use crate::crd::gordo::{load_gordo_resource, GordoStatus};
 use crate::GordoEnvironmentConfig;
+use kube::api::ListParams;
 
 pub async fn monitor_models(client: &APIClient, namespace: &str, _env_config: &GordoEnvironmentConfig) -> ! {
     let model_resource: Api<Model> = Api::customResource(client.clone(), "models")
@@ -26,7 +28,7 @@ pub async fn monitor_models(client: &APIClient, namespace: &str, _env_config: &G
             .unwrap_or_else(|e| panic!("Failed to poll model informer: {:?}", e));
 
         while let Some(event) = model_informer.pop() {
-            if let Err(err) = handle_model_event(event, &model_resource).await {
+            if let Err(err) = handle_model_event(&client, event, &model_resource, &namespace).await {
                 error!("Watch event error for model informer: {:?}", err);
                 outdated_version = true;
             };
@@ -41,25 +43,66 @@ pub async fn monitor_models(client: &APIClient, namespace: &str, _env_config: &G
 }
 
 /// Do what needs to be done with a model event
-async fn handle_model_event(event: WatchEvent<Model>, resource: &Api<Model>) -> Result<(), kube::ApiError> {
+async fn handle_model_event(
+    client: &APIClient,
+    event: WatchEvent<Model>,
+    resource: &Api<Model>,
+    namespace: &str,
+) -> Result<(), kube::ApiError> {
     match event {
         WatchEvent::Added(model) => {
             info!("New gordo model: {:?} - {:?}", model.metadata.name, model.status);
-            let status = json!({ "status": ModelStatus::default() });
-            resource
-                .patch_status(
-                    &model.metadata.name,
-                    &PatchParams::default(),
-                    serde_json::to_vec(&status).unwrap(),
-                )
-                .await
-                .expect("Failed to patch model status!");
+            if let Err(err) = update_gordo_models_build_count(&model, &client, &resource, &namespace).await {
+                error!(
+                    "Failed to update Gordo.n-models-built count for Model '{}' with error: {:?}",
+                    &model.metadata.name, err
+                );
+            };
         }
         WatchEvent::Modified(model) => {
             info!("Modified gordo model: {:?} - {:?}", model.metadata.name, model.status);
         }
         WatchEvent::Deleted(model) => info!("Deleted gordo model: {:?} - {:?}", model.metadata.name, model.status),
         WatchEvent::Error(err) => return Err(err),
+    }
+    Ok(())
+}
+
+/// Given a `Model`, update the associated `Gordo` with the current number of models
+/// which are built for it.
+async fn update_gordo_models_build_count(
+    model: &Model,
+    client: &APIClient,
+    resource: &Api<Model>,
+    namespace: &str,
+) -> Result<(), kube::Error> {
+    match model.metadata.labels.get("applications.gordo.equinor.com/project-name") {
+        Some(project_name) => {
+            // Get the project-name, which is the name of the Gordo
+            // Find the owning Gordo
+            let gordo_api = load_gordo_resource(&client, &namespace);
+            let gordo = gordo_api.get(project_name).await?;
+
+            // Get all models for this Gordo
+            let mut lp = ListParams::default();
+            lp.label_selector = Some(format!("applications.gordo.equinor.com/project-name={}", &project_name));
+            let models = resource.list(&lp).await?;
+
+            // Get the current status of this gordo, and then update the number of built models
+            // with the current list count of models found
+            let mut status = GordoStatus::from(&gordo);
+            status.n_models_built = models.items.len();
+            let patch = serde_json::to_vec(&json!({ "status": status })).unwrap();
+
+            // Patch the status with the current models built
+            gordo_api
+                .patch_status(&gordo.metadata.name, &PatchParams::default(), patch)
+                .await?;
+        }
+        None => warn!(
+            "Model {} did not have 'applications.gordo.equinor.com/project-name' defined, cannot update owning Gordo.",
+            &model.metadata.name
+        ),
     }
     Ok(())
 }

--- a/src/crd/model/mod.rs
+++ b/src/crd/model/mod.rs
@@ -78,8 +78,7 @@ async fn update_gordo_models_build_count(
 ) -> Result<(), kube::Error> {
     match model.metadata.labels.get("applications.gordo.equinor.com/project-name") {
         Some(project_name) => {
-            // Get the project-name, which is the name of the Gordo
-            // Find the owning Gordo
+            // Find the owning Gordo, which is the project name
             let gordo_api = load_gordo_resource(&client, &namespace);
             let gordo = gordo_api.get(project_name).await?;
 
@@ -88,8 +87,7 @@ async fn update_gordo_models_build_count(
             lp.label_selector = Some(format!("applications.gordo.equinor.com/project-name={}", &project_name));
             let models = resource.list(&lp).await?;
 
-            // Get the current status of this gordo, and then update the number of built models
-            // with the current list count of models found
+            // Create a status from the current status, and then update the number of built models
             let mut status = GordoStatus::from(&gordo);
             status.n_models_built = models.items.len();
             let patch = serde_json::to_vec(&json!({ "status": status })).unwrap();

--- a/src/crd/model/mod.rs
+++ b/src/crd/model/mod.rs
@@ -1,106 +1,57 @@
 pub mod model;
 pub use model::*;
 
-use kube::{
-    api::{Api, Informer, PatchParams, WatchEvent},
-    client::APIClient,
-};
-use log::{error, info, warn};
+use kube::{api::PatchParams, client::APIClient};
+use log::error;
 use serde_json::json;
 
 use crate::crd::gordo::{load_gordo_resource, GordoStatus};
 use crate::GordoEnvironmentConfig;
-use kube::api::ListParams;
+use kube::api::Reflector;
 
 pub async fn monitor_models(client: &APIClient, namespace: &str, _env_config: &GordoEnvironmentConfig) -> ! {
-    let model_resource: Api<Model> = Api::customResource(client.clone(), "models")
-        .version("v1")
-        .group("equinor.com")
-        .within(&namespace);
-    let model_informer: Informer<Model> = Informer::new(model_resource.clone()).init().await.unwrap();
+    let model_resource = load_model_resource(&client, &namespace);
+    let gordo_resource = load_gordo_resource(&client, &namespace);
 
-    let mut outdated_version = false;
+    let model_reflector = Reflector::new(model_resource.clone()).init().await.unwrap();
+    let gordo_reflector = Reflector::new(gordo_resource.clone()).init().await.unwrap();
+
     loop {
-        // updates to models
-        model_informer
-            .poll()
-            .await
-            .unwrap_or_else(|e| panic!("Failed to poll model informer: {:?}", e));
+        let models = model_reflector.read().unwrap();
+        let gordos = gordo_reflector.read().unwrap();
 
-        while let Some(event) = model_informer.pop() {
-            if let Err(err) = handle_model_event(&client, event, &model_resource, &namespace).await {
-                error!("Watch event error for model informer: {:?}", err);
-                outdated_version = true;
-            };
+        // Compare each Gordo's n-models-built against the total models currently found for that Gordo
+        for gordo in gordos {
+            let n_models_built = models
+                .iter()
+                .filter(|model| {
+                    model
+                        .metadata
+                        .ownerReferences
+                        .iter()
+                        .any(|owner_ref| owner_ref.name == gordo.metadata.name)
+                })
+                .count();
+
+            // If the gordo's current status of built models doesn't match the current models existing
+            // we need to patch its status to reflect the actual models built for it.
+            if gordo.status.clone().unwrap_or_default().n_models_built != n_models_built {
+                let mut status = GordoStatus::from(&gordo);
+                status.n_models_built = n_models_built;
+
+                let patch = serde_json::to_vec(&json!({ "status": status })).unwrap();
+                let pp = PatchParams::default();
+
+                if let Err(err) = gordo_resource.patch_status(&gordo.metadata.name, &pp, patch).await {
+                    error!(
+                        "Failed to patch status of Gordo '{}' - error: {:?}",
+                        &gordo.metadata.name, err
+                    );
+                }
+            }
         }
 
-        // Reset the informer if an error was encountred.
-        if outdated_version {
-            model_informer.reset().await.unwrap();
-            outdated_version = false;
-        }
+        model_reflector.poll().await.unwrap();
+        gordo_reflector.poll().await.unwrap();
     }
-}
-
-/// Do what needs to be done with a model event
-async fn handle_model_event(
-    client: &APIClient,
-    event: WatchEvent<Model>,
-    resource: &Api<Model>,
-    namespace: &str,
-) -> Result<(), kube::ApiError> {
-    match event {
-        WatchEvent::Added(model) => {
-            info!("New gordo model: {:?} - {:?}", model.metadata.name, model.status);
-            if let Err(err) = update_gordo_models_build_count(&model, &client, &resource, &namespace).await {
-                error!(
-                    "Failed to update Gordo.n-models-built count for Model '{}' with error: {:?}",
-                    &model.metadata.name, err
-                );
-            };
-        }
-        WatchEvent::Modified(model) => {
-            info!("Modified gordo model: {:?} - {:?}", model.metadata.name, model.status);
-        }
-        WatchEvent::Deleted(model) => info!("Deleted gordo model: {:?} - {:?}", model.metadata.name, model.status),
-        WatchEvent::Error(err) => return Err(err),
-    }
-    Ok(())
-}
-
-/// Given a `Model`, update the associated `Gordo` with the current number of models
-/// which are built for it.
-async fn update_gordo_models_build_count(
-    model: &Model,
-    client: &APIClient,
-    resource: &Api<Model>,
-    namespace: &str,
-) -> Result<(), kube::Error> {
-    match model.metadata.labels.get("applications.gordo.equinor.com/project-name") {
-        Some(project_name) => {
-            // Find the owning Gordo, which is the project name
-            let gordo_api = load_gordo_resource(&client, &namespace);
-            let gordo = gordo_api.get(project_name).await?;
-
-            // Get all models for this Gordo
-            let mut lp = ListParams::default();
-            lp.label_selector = Some(format!("applications.gordo.equinor.com/project-name={}", &project_name));
-            let models = resource.list(&lp).await?;
-
-            // Create a status from the current status, and then update the number of built models
-            let mut status = GordoStatus::from(&gordo);
-            status.n_models_built = models.items.len();
-            let patch = serde_json::to_vec(&json!({ "status": status })).unwrap();
-
-            // Patch the status with the current models built
-            gordo_api
-                .patch_status(&gordo.metadata.name, &PatchParams::default(), patch)
-                .await?;
-        }
-        None => warn!(
-            "Model {} did not have 'applications.gordo.equinor.com/project-name' defined, cannot update owning Gordo.",
-            &model.metadata.name
-        ),
-    }
-    Ok(())
 }

--- a/src/crd/model/model.rs
+++ b/src/crd/model/model.rs
@@ -1,4 +1,5 @@
-use kube::api::Object;
+use kube::api::{Api, Object};
+use kube::client::APIClient;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -29,4 +30,11 @@ impl Default for ModelStatus {
     fn default() -> Self {
         ModelStatus::Unknown
     }
+}
+
+pub fn load_model_resource(client: &APIClient, namespace: &str) -> Api<Model> {
+    Api::customResource(client.clone(), "models")
+        .version("v1")
+        .group("equinor.com")
+        .within(&namespace)
 }

--- a/src/tests/helpers.rs
+++ b/src/tests/helpers.rs
@@ -13,15 +13,6 @@ pub async fn client() -> APIClient {
     APIClient::new(config)
 }
 
-// Get an API to the Gordo custom resource
-pub fn gordo_custom_resource_api(client: APIClient) -> Api<Gordo> {
-    let gordos: Api<Gordo> = Api::customResource(client, "gordos")
-        .version("v1")
-        .group("equinor.com")
-        .within("default");
-    gordos
-}
-
 // Remove _all_ gordos.
 pub async fn remove_gordos(gordos: &Api<Gordo>) {
     for gordo in gordos.list(&ListParams::default()).await.unwrap().items.iter() {
@@ -33,8 +24,8 @@ pub async fn remove_gordos(gordos: &Api<Gordo>) {
 }
 
 // Get the repo's example `Gordo` config file
-pub fn gordo_example_config() -> Value {
-    let config_str = std::fs::read_to_string(format!("{}/example-gordo.yaml", env!("CARGO_MANIFEST_DIR")))
+pub fn example_config(name: &str) -> Value {
+    let config_str = std::fs::read_to_string(format!("{}/{}", env!("CARGO_MANIFEST_DIR"), name))
         .expect("Failed to read config file");
     serde_yaml::from_str(&config_str).expect("Unable to parse config file into yaml")
 }


### PR DESCRIPTION
Setup `monitor_models` to have a reflector for `Gordo`s and `Model`s.

At each iteration, look at each `Gordo` and filter down the `Model`s which belong to that `Gordo` and ensure the `status.n-models-built` reflects the correct number of models for that `Gordo`