### PR TITLE
Split into lib/bin and integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
           command: kustomize build k8s
 
       - run:
-          name: Apply CRD to cluster
+          name: Apply CRDs to cluster
           command: kubectl apply -k k8s -n default
 
       - run:
@@ -115,8 +115,21 @@ jobs:
           command: kubectl get models
 
       - run:
-          name: Rust Test
-          command: cargo test -- --test-threads=1
+          name: Unit Tests
+          command: cargo test --tests -- --test-threads=1
+
+      - run:
+          name: Start Gordo Controller
+          command: cargo run
+          background: true
+
+      - run:
+          name: Sleep
+          command: sleep 10
+
+      - run:
+          name: Integration Tests
+          command: cargo test --examples
 
   build-image:
     machine:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,3 @@ futures = "0.3.1"
 [dev-dependencies]
 serde_yaml = "0.8.11"
 tokio-test = "0.2.0-alpha.6"
-
-[[bin]]
-name = "gordo-controller"
-path = "src/main.rs"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GORDO_CONTROLLER_IMG_NAME := equinor/gordo-controller
 
 test:
 	kubectl config use-context minikube
-	cargo test -- --test-threads=1
+	cargo test --tests -- --test-threads=1
 
 controller:
 	docker build . -f Dockerfile-controller -t $(GORDO_CONTROLLER_IMG_NAME)

--- a/examples/apply_gordo.rs
+++ b/examples/apply_gordo.rs
@@ -1,0 +1,68 @@
+use kube::config;
+use serde_json::Value;
+use serde_yaml;
+
+use failure::_core::time::Duration;
+use gordo_controller::crd::{gordo::load_gordo_resource, model::load_model_resource};
+use kube::api::{DeleteParams, ListParams, PostParams};
+use kube::client::APIClient;
+
+#[tokio::main]
+#[test]
+async fn main() {
+    let gordo_raw = std::fs::read_to_string(format!("{}/example-gordo.yaml", env!("CARGO_MANIFEST_DIR"))).unwrap();
+    let gordo: Value = serde_yaml::from_str(&gordo_raw).unwrap();
+
+    let client = APIClient::new(config::load_kube_config().await.unwrap());
+
+    let gordo_api = load_gordo_resource(&client, "default");
+
+    // Presently, no gordos, but after submitting one should be available
+    assert_eq!(gordo_api.list(&ListParams::default()).await.unwrap().items.len(), 0);
+    assert!(gordo_api
+        .create(&PostParams::default(), serde_json::to_vec(&gordo).unwrap())
+        .await
+        .is_ok(),);
+    assert_eq!(gordo_api.list(&ListParams::default()).await.unwrap().items.len(), 1);
+
+    // Wait for running controller to update the status
+    std::thread::sleep(Duration::from_secs(20));
+
+    // Fetch and check number of models
+    let gordo = gordo_api.get("test-project-name").await.unwrap();
+    assert_eq!(gordo.spec.config.n_models(), 9);
+    assert!(gordo.status.is_some());
+
+    let status = gordo.status.unwrap();
+    assert_eq!(status.n_models, 9);
+    assert_eq!(status.n_models_built, 0); // no models built yet.
+
+    // simulate a 'finished' model by submitting the example model
+    let model_raw = std::fs::read_to_string(format!("{}/example-model.yaml", env!("CARGO_MANIFEST_DIR"))).unwrap();
+    let model: Value = serde_yaml::from_str(&model_raw).unwrap();
+
+    let model_api = load_model_resource(&client, "default");
+    assert!(model_api
+        .create(&PostParams::default(), serde_json::to_vec(&model).unwrap())
+        .await
+        .is_ok());
+
+    // Wait for controller to pick up the change
+    std::thread::sleep(Duration::from_secs(30));
+
+    assert_eq!(model_api.list(&ListParams::default()).await.unwrap().items.len(), 1);
+
+    // Now Gordo's status should report 1 model built
+    let gordo = gordo_api.get("test-project-name").await.unwrap();
+    assert_eq!(gordo.status.unwrap().n_models_built, 1);
+
+    // Cleanup
+    assert!(gordo_api
+        .delete("test-project-name", &DeleteParams::default())
+        .await
+        .is_ok());
+    assert!(model_api
+        .delete("gordo-model-name", &DeleteParams::default())
+        .await
+        .is_ok());
+}

--- a/src/crd/gordo/gordo.rs
+++ b/src/crd/gordo/gordo.rs
@@ -84,7 +84,7 @@ impl Default for GordoSubmissionStatus {
 /// has set in its `metadata.generation`; meaning changes have been submitted to the resource but
 /// the `GordoStatus` has not been updated to reflect this and therefore needs to be submitted to
 /// the workflow generator job.
-pub(crate) async fn launch_waiting_gordo_workflows(
+pub async fn launch_waiting_gordo_workflows(
     resource: &Api<Gordo>,
     client: &APIClient,
     namespace: &str,
@@ -134,7 +134,7 @@ pub(crate) async fn launch_waiting_gordo_workflows(
 
 /// Start a gordo-deploy job using this `Gordo`.
 /// Will patch the status of the `Gordo` to reflect the current revision number
-pub(crate) async fn start_gordo_deploy_job(
+pub async fn start_gordo_deploy_job(
     gordo: &Gordo,
     client: &APIClient,
     resource: &Api<Gordo>,
@@ -179,7 +179,7 @@ pub(crate) async fn start_gordo_deploy_job(
 }
 
 /// Remove any gordo deploy jobs associated with this `Gordo`
-pub(crate) async fn remove_gordo_deploy_jobs(gordo: &Gordo, client: &APIClient, namespace: &str) -> () {
+pub async fn remove_gordo_deploy_jobs(gordo: &Gordo, client: &APIClient, namespace: &str) -> () {
     info!("Removing any gordo-deploy jobs for Gordo: '{}'", &gordo.metadata.name);
 
     let jobs = Api::v1Job(client.clone()).within(&namespace);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,27 @@
+use serde::Deserialize;
+
+pub mod crd;
+pub mod deploy_job;
+pub use crd::gordo::Gordo;
+pub use deploy_job::DeployJob;
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct GordoEnvironmentConfig {
+    deploy_image: String,
+}
+impl Default for GordoEnvironmentConfig {
+    fn default() -> Self {
+        GordoEnvironmentConfig {
+            deploy_image: "auroradevacr.azurecr.io/gordo-infrastructure/gordo-deploy".to_owned(),
+        }
+    }
+}
+
+// Get a minor version from standard SemVer string
+pub fn minor_version(deploy_version: &str) -> Option<u32> {
+    deploy_version
+        .split('.')
+        .nth(1)
+        .map(|v| v.parse::<u32>().ok())
+        .unwrap_or(None)
+}

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,3 +1,0 @@
-pub(crate) mod helpers;
-#[cfg(test)]
-pub(crate) mod test_controller;

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -3,7 +3,7 @@ use kube::{api::Api, client::APIClient, config};
 use serde_json::Value;
 use serde_yaml;
 
-use crate::crd::gordo::Gordo;
+use gordo_controller::crd::gordo::Gordo;
 
 // Get the `APIClient` using current kube config
 pub async fn client() -> APIClient {

--- a/tests/test_controller.rs
+++ b/tests/test_controller.rs
@@ -2,9 +2,10 @@ use kube::api::Api;
 use kube::api::{DeleteParams, ListParams, PostParams};
 use tokio_test::block_on;
 
-use crate::crd::gordo::load_gordo_resource;
-use crate::tests::helpers;
-use crate::{deploy_job::DeployJob, GordoEnvironmentConfig};
+mod helpers;
+
+use gordo_controller::crd::gordo::load_gordo_resource;
+use gordo_controller::{deploy_job::DeployJob, GordoEnvironmentConfig};
 
 // We can create a gordo using the `example-gordo.yaml` file in the repo.
 #[test]
@@ -69,7 +70,7 @@ fn test_launch_waiting_gordos() {
 
         // Launch the waiting config.
         let resource = load_gordo_resource(&client, "default");
-        crate::crd::gordo::launch_waiting_gordo_workflows(
+        gordo_controller::crd::gordo::launch_waiting_gordo_workflows(
             &resource,
             &client,
             "default",
@@ -81,7 +82,7 @@ fn test_launch_waiting_gordos() {
         assert_eq!(jobs.list(&ListParams::default()).await.unwrap().items.len(), 1);
 
         // Delete all jobs
-        crate::crd::gordo::remove_gordo_deploy_jobs(&new_gordo, &client, "default").await;
+        gordo_controller::crd::gordo::remove_gordo_deploy_jobs(&new_gordo, &client, "default").await;
 
         // And finally, we should have zero jobs
         std::thread::sleep(std::time::Duration::from_secs(8)); // Time for step above to finish
@@ -91,9 +92,9 @@ fn test_launch_waiting_gordos() {
 
 #[test]
 fn test_minor_version() {
-    assert_eq!(crate::minor_version("0.33.0"), Some(33));
-    assert_eq!(crate::minor_version("0.31.12"), Some(31));
-    assert_eq!(crate::minor_version("0.abc.def"), None);
+    assert_eq!(gordo_controller::minor_version("0.33.0"), Some(33));
+    assert_eq!(gordo_controller::minor_version("0.31.12"), Some(31));
+    assert_eq!(gordo_controller::minor_version("0.abc.def"), None);
 }
 
 #[test]

--- a/tests/test_controller.rs
+++ b/tests/test_controller.rs
@@ -81,12 +81,14 @@ fn test_launch_waiting_gordos() {
         // Now we should have one job.
         assert_eq!(jobs.list(&ListParams::default()).await.unwrap().items.len(), 1);
 
-        // Delete all jobs
+        // Delete all gordos and jobs
         gordo_controller::crd::gordo::remove_gordo_deploy_jobs(&new_gordo, &client, "default").await;
+        assert!(gordos.delete(&new_gordo.metadata.name, &DeleteParams::default()).await.is_ok());
 
-        // And finally, we should have zero jobs
+        // And finally, we should have zero jobs and gordos
         std::thread::sleep(std::time::Duration::from_secs(8)); // Time for step above to finish
         assert_eq!(jobs.list(&ListParams::default()).await.unwrap().items.len(), 0);
+        assert_eq!(gordos.list(&ListParams::default()).await.unwrap().items.len(), 0);
     })
 }
 


### PR DESCRIPTION
- Splits the project into `lib` and a `bin` to help separating into proper unittests and integration tests
- Adds an example test to serve as an integration test

Will close #56 