### PR TITLE
Remove duplicate reflectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "gordo-controller"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "actix-web 2.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gordo-controller"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 

--- a/src/crd/model/mod.rs
+++ b/src/crd/model/mod.rs
@@ -1,57 +1,49 @@
 pub mod model;
 pub use model::*;
 
-use kube::{api::PatchParams, client::APIClient};
+use kube::api::PatchParams;
 use log::error;
 use serde_json::json;
 
-use crate::crd::gordo::{load_gordo_resource, GordoStatus};
-use crate::GordoEnvironmentConfig;
-use kube::api::Reflector;
+use crate::crd::gordo::GordoStatus;
+use crate::Controller;
 
-pub async fn monitor_models(client: &APIClient, namespace: &str, _env_config: &GordoEnvironmentConfig) -> ! {
-    let model_resource = load_model_resource(&client, &namespace);
-    let gordo_resource = load_gordo_resource(&client, &namespace);
+pub async fn monitor_models(controller: &Controller) -> () {
+    let models = controller.model_state().await;
+    let gordos = controller.gordo_state().await;
 
-    let model_reflector = Reflector::new(model_resource.clone()).init().await.unwrap();
-    let gordo_reflector = Reflector::new(gordo_resource.clone()).init().await.unwrap();
+    // Compare each Gordo's n-models-built against the total models currently found for that Gordo
+    for gordo in gordos {
+        let n_models_built = models
+            .iter()
+            .filter(|model| {
+                model
+                    .metadata
+                    .ownerReferences
+                    .iter()
+                    .any(|owner_ref| owner_ref.name == gordo.metadata.name)
+            })
+            .count();
 
-    loop {
-        let models = model_reflector.read().unwrap();
-        let gordos = gordo_reflector.read().unwrap();
+        // If the gordo's current status of built models doesn't match the current models existing
+        // we need to patch its status to reflect the actual models built for it.
+        if gordo.status.clone().unwrap_or_default().n_models_built != n_models_built {
+            let mut status = GordoStatus::from(&gordo);
+            status.n_models_built = n_models_built;
 
-        // Compare each Gordo's n-models-built against the total models currently found for that Gordo
-        for gordo in gordos {
-            let n_models_built = models
-                .iter()
-                .filter(|model| {
-                    model
-                        .metadata
-                        .ownerReferences
-                        .iter()
-                        .any(|owner_ref| owner_ref.name == gordo.metadata.name)
-                })
-                .count();
+            let patch = serde_json::to_vec(&json!({ "status": status })).unwrap();
+            let pp = PatchParams::default();
 
-            // If the gordo's current status of built models doesn't match the current models existing
-            // we need to patch its status to reflect the actual models built for it.
-            if gordo.status.clone().unwrap_or_default().n_models_built != n_models_built {
-                let mut status = GordoStatus::from(&gordo);
-                status.n_models_built = n_models_built;
-
-                let patch = serde_json::to_vec(&json!({ "status": status })).unwrap();
-                let pp = PatchParams::default();
-
-                if let Err(err) = gordo_resource.patch_status(&gordo.metadata.name, &pp, patch).await {
-                    error!(
-                        "Failed to patch status of Gordo '{}' - error: {:?}",
-                        &gordo.metadata.name, err
-                    );
-                }
+            if let Err(err) = controller
+                .gordo_resource
+                .patch_status(&gordo.metadata.name, &pp, patch)
+                .await
+            {
+                error!(
+                    "Failed to patch status of Gordo '{}' - error: {:?}",
+                    &gordo.metadata.name, err
+                );
             }
         }
-
-        model_reflector.poll().await.unwrap();
-        gordo_reflector.poll().await.unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ async fn main() -> () {
             App::new()
                 .data(controller.clone())
                 .wrap(middleware::Logger::default().exclude("/health"))
+                .wrap(middleware::Compress::default())
                 .service(web::resource("/health").to(views::health))
                 .service(web::resource("/gordos").to(views::gordos))
                 .service(web::resource("/gordos/{name}").to(views::get_gordo))

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -1,9 +1,9 @@
-use gordo_controller::{controller_init, load_kube_config, views, Controller, Gordo, GordoEnvironmentConfig};
 use tokio_test::block_on;
 
 use actix_web::web::Json;
 use actix_web::{http::StatusCode, test, web};
-use gordo_controller::crd::model::Model;
+use gordo_controller::{controller_init, load_kube_config, views, Controller, GordoEnvironmentConfig};
+use gordo_controller::{crd::gordo::Gordo, crd::model::Model};
 
 #[test]
 fn test_view_health() {


### PR DESCRIPTION
#67 added support for exposting the current state of `Gordo` and `Model` resources, but also created multiple instances of the `Reflector<K>`. 

When running on gordotest47 with ~1200 models at the time I noticed that memory use was at 180Mi because we, in effect, created 3 `Reflector<Gordo>`s and 2 `Reflector<Model>`s. 

Now we only create one each and use those for updating / reacting to state as well as reporting in the API endpoints.

:golf: Bonus :golfing_man: 
When playing with it on the cluster yesterday, realized we didn't have compression enabled and the solution was a one liner. :man_shrugging: 
