### PR TITLE
Add project version/revision to deploy job

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,7 @@ name = "gordo-controller"
 version = "0.5.0"
 dependencies = [
  "actix-web 2.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "envy 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 actix-web = "2.0.0-alpha.2"
+chrono = "0.4"
 kube = { version = "0.20.0", features = ["openapi"] }
 k8s-openapi = { version = "0.6.0", default-features = false, features = ["v1_15"] }
 log = "0.4.8"

--- a/src/deploy_job.rs
+++ b/src/deploy_job.rs
@@ -35,12 +35,15 @@ impl DeployJob {
         };
 
         // Build up the gordo-deploy environment variables
+        let project_revision = chrono::Utc::now().timestamp_millis().to_string();
         let mut environment = vec![
             gordo_deploy_key_val,
             json!({"name": "ARGO_SUBMIT", "value":  "true"}),
             json!({"name": "WORKFLOW_GENERATOR_PROJECT_NAME", "value": &gordo.metadata.name}),
             json!({"name": "WORKFLOW_GENERATOR_OWNER_REFERENCES", "value": owner_ref_as_string}),
+            json!({"name": "WORKFLOW_GENERATOR_PROJECT_VERSION", "value": project_revision}),
         ];
+
         // push in any that were supplied by the Gordo.spec.gordo_environment mapping
         gordo.spec.deploy_environment.as_ref().map(|env| {
             env.iter().for_each(|(key, value)| {


### PR DESCRIPTION
Part of #59 

Creates a timestamp in milliseconds the same way the default is in workflow generator, and passes the environment variable `WORKFLOW_GENERATOR_PROJECT_VERSION` in the manifest's environment.