### PR TITLE
Update project revision in gordo

### DIFF
--- a/src/deploy_job.rs
+++ b/src/deploy_job.rs
@@ -13,6 +13,8 @@ pub struct DeployJob {
     pub metadata: ObjectMeta,
     pub spec: DeployJobSpec,
     pub status: Option<kube::api::Void>,
+    #[serde(skip)] // This is not part of a k8s resource; for internal use.
+    pub revision: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -83,6 +85,7 @@ impl DeployJob {
                 },
             },
             status: None,
+            revision: project_revision,
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,15 +31,6 @@ impl Default for GordoEnvironmentConfig {
     }
 }
 
-// Get a minor version from standard SemVer string
-pub fn minor_version(deploy_version: &str) -> Option<u32> {
-    deploy_version
-        .split('.')
-        .nth(1)
-        .map(|v| v.parse::<u32>().ok())
-        .unwrap_or(None)
-}
-
 /// Load the `kube::Configuration` giving priority to local, falling back to in-cluster config
 pub async fn load_kube_config() -> Configuration {
     config::load_kube_config()

--- a/tests/test_controller.rs
+++ b/tests/test_controller.rs
@@ -45,13 +45,6 @@ fn test_create_gordo() {
 }
 
 #[test]
-fn test_minor_version() {
-    assert_eq!(gordo_controller::minor_version("0.33.0"), Some(33));
-    assert_eq!(gordo_controller::minor_version("0.31.12"), Some(31));
-    assert_eq!(gordo_controller::minor_version("0.abc.def"), None);
-}
-
-#[test]
 fn test_deploy_job_name() {
     let prefix = "gordo-dpl-";
 
@@ -80,11 +73,10 @@ fn test_deploy_job_injects_project_version() {
 
     let deploy_job = DeployJob::new(&gordo, &GordoEnvironmentConfig::default());
 
-    let env: Vec<HashMap<String, String>> =
-        serde_json::from_value(deploy_job.manifest["spec"]["template"]["spec"]["containers"][0]["env"].clone())
-            .unwrap();
-
-    assert!(env
+    assert!(deploy_job.spec.template.spec.unwrap().containers[0]
+        .env
+        .as_ref()
+        .unwrap()
         .iter()
-        .any(|kv| kv.get("name") == Some(&"WORKFLOW_GENERATOR_PROJECT_VERSION".to_owned())));
+        .any(|ev| ev.name == "WORKFLOW_GENERATOR_PROJECT_VERSION"));
 }


### PR DESCRIPTION
Will close #59 

- Use k8s-openapi types for `DeployJob` so that itself is a valid k8s type.
- Remove minor version check for `0.33.0` and test
- Add the `project-revision` to the `Gordo` after launching `DeployJob`