### PR TITLE
Filter models on gordo project revision

### DIFF
--- a/examples/apply_gordo.rs
+++ b/examples/apply_gordo.rs
@@ -3,6 +3,7 @@ use serde_json::Value;
 use serde_yaml;
 
 use failure::_core::time::Duration;
+use gordo_controller::crd::model::Model;
 use gordo_controller::crd::{gordo::load_gordo_resource, model::load_model_resource};
 use kube::api::{DeleteParams, ListParams, PostParams};
 use kube::client::APIClient;
@@ -33,13 +34,20 @@ async fn main() {
     assert_eq!(gordo.spec.config.n_models(), 9);
     assert!(gordo.status.is_some());
 
-    let status = gordo.status.unwrap();
+    let status = gordo.status.as_ref().unwrap();
     assert_eq!(status.n_models, 9);
     assert_eq!(status.n_models_built, 0); // no models built yet.
 
     // simulate a 'finished' model by submitting the example model
     let model_raw = std::fs::read_to_string(format!("{}/example-model.yaml", env!("CARGO_MANIFEST_DIR"))).unwrap();
     let model: Value = serde_yaml::from_str(&model_raw).unwrap();
+    let mut model: Model = serde_json::from_value(model).unwrap();
+
+    // Update the model to match the project-revision set by the controller
+    model.metadata.labels.insert(
+        "applications.gordo.equinor.com/project-version".to_owned(),
+        gordo.status.unwrap().project_revision,
+    );
 
     let model_api = load_model_resource(&client, "default");
     assert!(model_api

--- a/src/crd/gordo/gordo.rs
+++ b/src/crd/gordo/gordo.rs
@@ -57,7 +57,7 @@ pub struct GordoStatus {
     #[serde(rename = "n-models-built", default)]
     pub n_models_built: usize,
     #[serde(rename = "project-revision", default)]
-    pub project_revision: Option<String>,
+    pub project_revision: String,
 }
 
 impl From<&Gordo> for GordoStatus {
@@ -110,7 +110,7 @@ pub async fn start_gordo_deploy_job(
     }
 
     let mut status = GordoStatus::from(gordo);
-    status.project_revision = Some(job.revision.to_owned());
+    status.project_revision = job.revision.to_owned();
 
     // Update the status of this job
     info!(

--- a/src/crd/model/mod.rs
+++ b/src/crd/model/mod.rs
@@ -14,16 +14,7 @@ pub async fn monitor_models(controller: &Controller) -> () {
 
     // Compare each Gordo's n-models-built against the total models currently found for that Gordo
     for gordo in gordos {
-        let n_models_built = models
-            .iter()
-            .filter(|model| {
-                model
-                    .metadata
-                    .ownerReferences
-                    .iter()
-                    .any(|owner_ref| owner_ref.name == gordo.metadata.name)
-            })
-            .count();
+        let n_models_built = filter_models_on_gordo(&gordo, &models).count();
 
         // If the gordo's current status of built models doesn't match the current models existing
         // we need to patch its status to reflect the actual models built for it.


### PR DESCRIPTION
Will close #75 

Regarding route:`/models/<project-name>`

In addition to existing filtering of models matching the project-name/gordo name, return models which match that `Gordo`'s `project-revision` number as well.