### PR TITLE
Use project revision with gordo-components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "gordo-controller"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "actix-web 2.0.0-alpha.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gordo-controller"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Miles Granger <miles59923@gmail.com>"]
 edition = "2018"
 

--- a/examples/apply_gordo.rs
+++ b/examples/apply_gordo.rs
@@ -45,7 +45,7 @@ async fn main() {
 
     // Update the model to match the project-revision set by the controller
     model.metadata.labels.insert(
-        "applications.gordo.equinor.com/project-version".to_owned(),
+        "applications.gordo.equinor.com/project-revision".to_owned(),
         gordo.status.unwrap().project_revision,
     );
 

--- a/examples/query_server.rs
+++ b/examples/query_server.rs
@@ -52,9 +52,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Ok(gordo) = gordo_api.get(&gordo.metadata.name).await {
         match gordo.status {
             Some(status) => {
-                // Update this model's project-version to match the revision number given to the owning Gordo
+                // Update this model's project-revision to match the revision number given to the owning Gordo
                 model.metadata.labels.insert(
-                    "applications.gordo.equinor.com/project-version".to_string(),
+                    "applications.gordo.equinor.com/project-revision".to_string(),
                     status.project_revision,
                 );
                 break;

--- a/k8s/model-crd.yaml
+++ b/k8s/model-crd.yaml
@@ -8,9 +8,9 @@ spec:
       description: Current status of the model
       name: ModelStatus
       type: string
-    - JSONPath: .metadata.labels.applications\.gordo\.equinor\.com/project-version
-      description: Project version
-      name: Project version
+    - JSONPath: .metadata.labels.applications\.gordo\.equinor\.com/project-revision
+      description: Project revision
+      name: Project revision
       type: string
     - JSONPath: .metadata.labels.applications\.gordo\.equinor\.com/project-name
       description: Project name

--- a/src/crd/model/model.rs
+++ b/src/crd/model/model.rs
@@ -41,7 +41,7 @@ pub fn load_model_resource(client: &APIClient, namespace: &str) -> Api<Model> {
 }
 
 /// Filter a collection of models to match a `Gordo` based on `OwnerReference`
-/// and the project-version of the `Model` matches the project-revision of the `Gordo`
+/// and the project-revision of the `Model` matches the project-revision of the `Gordo`
 pub fn filter_models_on_gordo<'a>(gordo: &'a Gordo, models: &'a [Model]) -> impl Iterator<Item = &'a Model> {
     models
         .iter()
@@ -59,7 +59,15 @@ pub fn filter_models_on_gordo<'a>(gordo: &'a Gordo, models: &'a [Model]) -> impl
                 model
                     .metadata
                     .labels
-                    .get("applications.gordo.equinor.com/project-version")
+                    .get("applications.gordo.equinor.com/project-revision")
+                    // TODO: Here for compatibility when gordo-components <= 0.46.0 used 'project-version' to refer to 'project-revision'
+                    // TODO: can remove when people have >= 0.47.0 of gordo
+                    .or_else(|| {
+                        model
+                            .metadata
+                            .labels
+                            .get("applications.gordo.equinor.com/project-version")
+                    })
                     == Some(&status.project_revision)
             }
             None => false,

--- a/src/deploy_job.rs
+++ b/src/deploy_job.rs
@@ -45,7 +45,7 @@ impl DeployJob {
             Self::env_var("ARGO_SUBMIT", "true"),
             Self::env_var("WORKFLOW_GENERATOR_PROJECT_NAME", &gordo.metadata.name),
             Self::env_var("WORKFLOW_GENERATOR_OWNER_REFERENCES", &owner_ref_as_string),
-            Self::env_var("WORKFLOW_GENERATOR_PROJECT_VERSION", &project_revision),
+            Self::env_var("WORKFLOW_GENERATOR_PROJECT_REVISION", &project_revision),
         ];
 
         // push in any that were supplied by the Gordo.spec.gordo_environment mapping

--- a/src/deploy_job.rs
+++ b/src/deploy_job.rs
@@ -46,6 +46,9 @@ impl DeployJob {
             Self::env_var("WORKFLOW_GENERATOR_PROJECT_NAME", &gordo.metadata.name),
             Self::env_var("WORKFLOW_GENERATOR_OWNER_REFERENCES", &owner_ref_as_string),
             Self::env_var("WORKFLOW_GENERATOR_PROJECT_REVISION", &project_revision),
+
+            // TODO: Backward compat. Until all have moved >=0.47.0 of gordo-components
+            Self::env_var("WORKFLOW_GENERATOR_PROJECT_VERSION", &project_revision),
         ];
 
         // push in any that were supplied by the Gordo.spec.gordo_environment mapping

--- a/tests/test_controller.rs
+++ b/tests/test_controller.rs
@@ -78,7 +78,7 @@ fn test_deploy_job_injects_project_version() {
         .as_ref()
         .unwrap()
         .iter()
-        .any(|ev| ev.name == "WORKFLOW_GENERATOR_PROJECT_VERSION"));
+        .any(|ev| ev.name == "WORKFLOW_GENERATOR_PROJECT_REVISION"));
 }
 
 #[test]


### PR DESCRIPTION
https://github.com/equinor/gordo-components/pull/804 has made gordo-components use `project-revision`.

This updates code to match that when getting and setting based on project revision; to include some backward compatibility by falling back to check for `project-version` 