### PR TITLE
Add default for Gordo.machines

### DIFF
--- a/src/crd/gordo/gordo.rs
+++ b/src/crd/gordo/gordo.rs
@@ -26,7 +26,7 @@ pub struct GordoSpec {
 /// The actual structure, so much as we need to parse, of a gordo config.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct GordoConfig {
-    #[serde(alias = "machines")]
+    #[serde(alias = "machines", default)]
     models: Vec<Value>,
     #[serde(default)]
     globals: Option<Value>,


### PR DESCRIPTION
Will close #80 

Problem
-----------
It appears we were handling a potential error in `.poll()` and logging it out. So on replication the controller didn't "go down" but however _once_ it goes down, ie. someone trying to restart it, it can't get going again because the first list call when creating the reflector uses `unwrap`

https://github.com/equinor/gordo-controller/blob/b46ed1c6cb367b91bd5f97a761c7d58b8e4d95e8/src/lib.rs#L62

I would contend this is just fine, because the controller can't actually run as expected unless this unwraps to a result, so it might as well crash if it doesn't

Solution?
------------
Since `globals` is optional, we have `default` for it set in the deserialization. Likewise, this simply adds the same for `machines`, so that if, by user error, it's spelled wrong, it will simply default to an empty `Vec`. 