### PR TITLE
Fixing circleci CI pipeline for the latest minikube version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,13 +85,10 @@ jobs:
             fi
       - run:
           command: >
-            sudo systemctl stop apt-daily.timer &&
-            sudo systemctl disable apt-daily.timer &&
-            sudo systemctl stop apt-daily.service &&
-            sleep 20 &&
-            sudo systemctl kill apt-daily.service &&
-            sleep 20 &&
-            sudo systemctl mask apt-daily.service &&
+            systemctl mask apt-daily.service apt-daily-upgrade.service &&
+            systemctl disable apt-daily.service apt-daily-upgrade.service &&
+            systemctl disable apt-daily.timer apt-daily-upgrade.timer &&
+            (ps aux | grep apt) &&
             sudo apt-get install -y conntrack &&
             curl -Lo minikube
             https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,9 +86,9 @@ jobs:
       - run:
           command: >
             sudo systemctl stop apt-daily.timer && \
-              systemctl disable apt-daily.timer && \
-              systemctl stop apt-daily.service && \
-              systemctl daemon-reload
+            sudo systemctl disable apt-daily.timer && \
+            sudo systemctl stop apt-daily.service && \
+            sleep 30
 
             sudo echo "apt processes:" && (ps aux | grep apt)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,10 +88,7 @@ jobs:
             sudo systemctl stop apt-daily.timer &&
             sudo systemctl disable apt-daily.timer &&
             sudo systemctl stop apt-daily.service &&
-            sleep 30
-
-            sudo echo "apt processes:" && (ps aux | grep apt)
-
+            sleep 30 &&
             sudo apt-get install -y conntrack &&
             curl -Lo minikube
             https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ jobs:
             fi
       - run:
           command: >
-            sudo systemctl stop apt-daily.timer && \
-            sudo systemctl disable apt-daily.timer && \
-            sudo systemctl stop apt-daily.service && \
-            sleep 30
+            sudo systemctl stop apt-daily.timer \
+            && sudo systemctl disable apt-daily.timer \
+            && sudo systemctl stop apt-daily.service \
+            && sleep 30
 
             sudo echo "apt processes:" && (ps aux | grep apt)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ jobs:
             sudo systemctl disable --now apt-daily.service apt-daily-upgrade.service &&
             sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer &&
             sleep 10 &&
+            sudo apt-get update &&
             sudo apt-get install -y conntrack &&
             curl -Lo minikube
             https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
             fi
       - run:
           command: >
+            systemctl stop apt-daily.service apt-daily-upgrade.service apt-daily.timer apt-daily-upgrade.timer &&
             systemctl mask apt-daily.service apt-daily-upgrade.service &&
             systemctl disable apt-daily.service apt-daily-upgrade.service &&
             systemctl disable apt-daily.timer apt-daily-upgrade.timer &&

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,10 @@ jobs:
             sudo systemctl stop apt-daily.timer &&
             sudo systemctl disable apt-daily.timer &&
             sudo systemctl stop apt-daily.service &&
-            sleep 30 &&
+            sleep 20 &&
+            sudo systemctl kill apt-daily.service &&
+            sleep 20 &&
+            sudo systemctl mask apt-daily.service &&
             sudo apt-get install -y conntrack &&
             curl -Lo minikube
             https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,12 +85,10 @@ jobs:
             fi
       - run:
           command: >
-            (ps aux | grep apt) &&
             sudo systemctl mask apt-daily.service apt-daily-upgrade.service &&
             sudo systemctl disable --now apt-daily.service apt-daily-upgrade.service &&
             sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer &&
-            sleep 30 &&
-            (ps aux | grep apt) &&
+            sleep 10 &&
             sudo apt-get install -y conntrack &&
             curl -Lo minikube
             https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,9 +85,11 @@ jobs:
             fi
       - run:
           command: >
-            systemctl mask apt-daily.service apt-daily-upgrade.service &&
-            systemctl disable --now apt-daily.service apt-daily-upgrade.service &&
-            systemctl disable --now apt-daily.timer apt-daily-upgrade.timer &&
+            (ps aux | grep apt) &&
+            sudo systemctl mask apt-daily.service apt-daily-upgrade.service &&
+            sudo systemctl disable --now apt-daily.service apt-daily-upgrade.service &&
+            sudo systemctl disable --now apt-daily.timer apt-daily-upgrade.timer &&
+            sleep 30 &&
             (ps aux | grep apt) &&
             sudo apt-get install -y conntrack &&
             curl -Lo minikube

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,10 @@ jobs:
             fi
       - run:
           command: >
-            sudo systemctl stop apt-daily.service && sleep 30
+            sudo systemctl stop apt-daily.timer && \
+              systemctl disable apt-daily.timer && \
+              systemctl stop apt-daily.service && \
+              systemctl daemon-reload
 
             sudo echo "apt processes:" && (ps aux | grep apt)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
             fi
       - run:
           command: >
+            sudo apt-get install -y conntrack
             curl -Lo minikube
             https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
             \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ jobs:
             fi
       - run:
           command: >
-            sudo apt-get install -y conntrack
+            sudo apt-get install -y conntrack &&
             curl -Lo minikube
             https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64
             \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,9 @@ jobs:
             fi
       - run:
           command: >
-            systemctl stop apt-daily.service apt-daily-upgrade.service apt-daily.timer apt-daily-upgrade.timer &&
             systemctl mask apt-daily.service apt-daily-upgrade.service &&
-            systemctl disable apt-daily.service apt-daily-upgrade.service &&
-            systemctl disable apt-daily.timer apt-daily-upgrade.timer &&
+            systemctl disable --now apt-daily.service apt-daily-upgrade.service &&
+            systemctl disable --now apt-daily.timer apt-daily-upgrade.timer &&
             (ps aux | grep apt) &&
             sudo apt-get install -y conntrack &&
             curl -Lo minikube

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ jobs:
             fi
       - run:
           command: >
-            sudo systemctl stop apt-daily.timer \
-            && sudo systemctl disable apt-daily.timer \
-            && sudo systemctl stop apt-daily.service \
-            && sleep 30
+            sudo systemctl stop apt-daily.timer &&
+            sudo systemctl disable apt-daily.timer &&
+            sudo systemctl stop apt-daily.service &&
+            sleep 30
 
             sudo echo "apt processes:" && (ps aux | grep apt)
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,8 @@ jobs:
             fi
       - run:
           command: >
+            sudo ps aux | grep apt
+
             sudo apt-get install -y conntrack &&
             curl -Lo minikube
             https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,9 @@ jobs:
             fi
       - run:
           command: >
-            sudo ps aux | grep apt
+            sudo systemctl stop apt-daily.service && sleep 30
+
+            sudo echo "apt processes:" && (ps aux | grep apt)
 
             sudo apt-get install -y conntrack &&
             curl -Lo minikube

--- a/src/crd/pod/mod.rs
+++ b/src/crd/pod/mod.rs
@@ -75,7 +75,7 @@ pub async fn monitor_pods(controller: &Controller) -> () {
                     info!("Found pods in phases {:?} for the model '{}'", pods_phases, model.metadata.name);
                     let mut new_status = status.clone();
                     let mut new_phase = new_status.phase.clone();
-                    if pods_phases.iter().all(|phase| *phase == SUCCEEDED) {
+                    if pods_phases.iter().any(|phase| *phase == SUCCEEDED) {
                         new_phase = ModelPhase::Succeeded;
                     } else if pods_phases.iter().any(|phase| *phase == RUNNING) {
                         new_phase = ModelPhase::InProgress;


### PR DESCRIPTION
Also contains improvements:
- Now we assume that if any of the model-builder pods are succeeded so as to cause this model is also Succeeded
